### PR TITLE
Fixes typo in readme.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@
 
 ```shell
 npm install --save-dev eslint \
-  eslint-babel \
+  babel-eslint \
   eslint-plugin-flow-check
 ```
 


### PR DESCRIPTION
I believe it is `babel-eslint` rather than `eslint-babel` that users need to install.

I love this plugin; it's the way I get flow support in spacemacs.