### PR TITLE
add new rules to differ between flow errors and warnings

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,21 @@ Make sure to enable the plugin via its rule.
 }
 ```
 
+To get a difference between flow errors and warnings you can also activate the according rules:
+
+```json
+{
+  "eslintConfig": {
+    "rules": {
+      "flow-check/error": "error",
+      "flow-check/warning": "warn",
+    },
+    "parser": "babel-eslint",
+    "plugins": ["flow-check"]
+  }
+}
+```
+
 Create a `.flowconfig` in your project root. See the [flow-type docs](https://flowtype.org/docs/advanced-configuration.html) for details.
 
 ```

--- a/source/check.js
+++ b/source/check.js
@@ -28,7 +28,8 @@ function check(source, options) {
 	const reports = flow({
 		root: projectRoot,
 		source,
-		fileName: options.fileName
+		fileName: options.fileName,
+		level: options.level
 	});
 
 	return [null, reports];

--- a/source/flow.js
+++ b/source/flow.js
@@ -32,21 +32,22 @@ function flow(options) {
 	}
 
 	const {errors} = JSON.parse(result.stdout);
+	return errors
+		.filter(({ level }) => options.level == null || level === options.level)
+		.map(error => {
+			const [leading, ...rest] = error.message;
+			const payload = rest.map(m => format(m, {
+				root: options.root
+			}));
 
-	return errors.map(error => {
-		const [leading, ...rest] = error.message;
-		const payload = rest.map(m => format(m, {
-			root: options.root
-		}));
-
-		return {
-			message: [leading.descr, ...payload].join(': '),
-			path: leading.path,
-			start: leading.loc.start.line,
-			end: leading.loc.end.line,
-			loc: leading.loc
-		};
-	});
+			return {
+				message: [leading.descr, ...payload].join(': '),
+				path: leading.path,
+				start: leading.loc.start.line,
+				end: leading.loc.end.line,
+				loc: leading.loc
+			};
+		});
 }
 
 function format(message, options) {

--- a/source/index.js
+++ b/source/index.js
@@ -1,41 +1,54 @@
 import check from './check';
 
+const createProgram = (context, level) => node => {
+	const fileName = context.getFilename();
+	const fileSource = context.getSourceCode();
+
+	const comments = node.comments.map(comment => {
+		return comment.value.replace(/\*/g, '').trim();
+	});
+
+	const pragma = Boolean(comments.find(comment => comment.startsWith('@flow')));
+
+	const [err, reports] = check(fileSource.text, {
+		fileName,
+		pragma,
+		level
+	});
+
+	if (err) {
+		context.report({
+			loc: {
+				start: {
+					line: 1
+				},
+				end: {
+					line: 1
+				}
+			},
+			message: `Error: ${err.message} ${err.fileName}`
+		});
+		return;
+	}
+
+	reports.forEach(report => context.report(report));
+};
+
 export default {
 	rules: {
 		check(context) {
 			return {
-				Program(node) {
-					const fileName = context.getFilename();
-					const fileSource = context.getSourceCode();
-
-					const comments = node.comments.map(comment => {
-						return comment.value.replace(/\*/g, '').trim();
-					});
-
-					const pragma = Boolean(comments.find(comment => comment.startsWith('@flow')));
-
-					const [err, reports] = check(fileSource.text, {
-						fileName,
-						pragma
-					});
-
-					if (err) {
-						context.report({
-							loc: {
-								start: {
-									line: 1
-								},
-								end: {
-									line: 1
-								}
-							},
-							message: `Error: ${err.message} ${err.fileName}`
-						});
-						return;
-					}
-
-					reports.forEach(report => context.report(report));
-				}
+				Program: createProgram(context)
+			};
+		},
+		error(context) {
+			return {
+				Program: createProgram(context, 'error')
+			};
+		},
+		warning(context) {
+			return {
+				Program: createProgram(context, 'warning')
 			};
 		}
 	}


### PR DESCRIPTION
this adds 2 new rules that can be used instead of `flow-check/check`:

* `flow-check/error` will only report flow errors
* `flow-check/warning` will only report flow warnings

`flow-check/check` works as before, no breaking change